### PR TITLE
Fix broken link in projects section

### DIFF
--- a/sections/projects.html
+++ b/sections/projects.html
@@ -102,7 +102,7 @@
                             <li>Built models including Logistic Regression, SVM, Naive Bayes, and LSTM.</li>
                             <li>Created a live prediction interface combining ML models and LLMs.</li>
                         </ul>
-                        <a href="https://github.com/AmiRaGaL/Twitter-Sentiment-Anaysis.git" target="_blank" class="btn btn-primary mt-3">View on GitHub</a>
+                        <a href="https://github.com/AmiRaGaL/Twitter-Sentiment-Analysis.git" target="_blank" class="btn btn-primary mt-3">View on GitHub</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- fix typo in the Twitter Sentiment Analysis project link

## Testing
- `grep -n 'Twitter-Sentiment-Analysis.git' -n sections/projects.html`

------
https://chatgpt.com/codex/tasks/task_e_683fe3ba62e88330aff8c986589de68d